### PR TITLE
build: [#15] Group Dependabot go-mod updates on weekly basis to save time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,16 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      gomod-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file to modify the update schedule and group dependencies.

Update schedule changes:

* Changed the update interval for `docker`, `github-actions`, and `gomod` package ecosystems from "daily" to "weekly".

Dependency grouping:

* Added a new group `gomod-all` for the `gomod` package ecosystem with a pattern that matches all dependencies.