### PR TITLE
fix: [#34] removed cache configuration from mcvs-registry

### DIFF
--- a/registry/config-example.yml
+++ b/registry/config-example.yml
@@ -4,8 +4,6 @@ log:
   fields:
     service: registry
 storage:
-  cache:
-    blobdescriptor: ""
   filesystem:
     rootdirectory: /var/lib/registry
 http:


### PR DESCRIPTION
## What
- Removed the `storage.cache` configuration option from the `mcvs-registry`

## Why
- Required to load images from files 