### PR TITLE
fix: [#34] added multiple copy of the config file

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -4,7 +4,10 @@ RUN apk update && \
     apk upgrade
 # A custom config file is needed to disable default cache
 # By default the cache is "blobdescriptor: inmemory"
-# The config-example.yml file of this repo disables it
+# The config-example.yml file of this repo can be found at:
 # https://github.com/distribution/distribution-library-image
+# File is copied to two different locations to keep
+# compatibility with registry:2.x and registry:3.x
 COPY ./config-example.yml /etc/docker/registry/config.yml
+COPY ./config-example.yml /etc/distribution/config.yml
 COPY ./backup-registry /var/lib/registry


### PR DESCRIPTION
## What
- Added extra line to copy the config file at new path 

## Why
- As of version `3.x` the config file has been moved to a new path according to the [release notes](https://github.com/distribution/distribution/releases/tag/v3.0.0-beta.1)