### PR TITLE
fix: [#34] added extra step to retrieve the registry content

### DIFF
--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -13,8 +13,10 @@ permissions:
   contents: read
   packages: write
 env:
-  BUILD_IMAGE_NAME: mcvs-registry
   DOCKERFILE_CONTEXT: ./registry
+  IMAGE_NAME: mcvs-registry
+  IMAGE_REPO: ghcr.io/${{ github.repository }}
+  IMAGE_TAG: pr-${{ github.event.number }}
   IMAGE_MANIFEST_LIST: nginx/nginx:1.27.0-alpine
   IMAGE_MANIFEST_SINGLE: nginx/nginx:1.27.0-alpine-slim-amd64
   REGCTL_VERSION: v0.8.0
@@ -79,7 +81,7 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ env.DOCKERFILE_CONTEXT }}
           dockle-accept-key: "curl,HOME,libcrypto3,libssl3,PATH"
-          images: ghcr.io/${{ github.repository }}/${{ matrix.build-args }}
+          images: ${{ env.IMAGE_REPO }}/${{ matrix.build-args }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get new registry catalog
         if: ${{ github.event_name == 'pull_request' }}
@@ -91,7 +93,7 @@ jobs:
           docker run -d \
             -p 5005:5000 \
             --name mcvs-registry \
-            ghcr.io/${{ github.repository }}/${{ env.BUILD_IMAGE_NAME }}:pr-${{ github.event.number }}
+            ${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
           curl --silent http://localhost:5005/v2/_catalog
 

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -13,9 +13,10 @@ permissions:
   contents: read
   packages: write
 env:
+  BUILD_IMAGE_NAME: mcvs-registry
   DOCKERFILE_CONTEXT: ./registry
-  IMAGE_MANIFEST_LIST: datadog/agent:7.59.0
-  IMAGE_MANIFEST_SINGLE: nginx/nginx:1.27.0
+  IMAGE_MANIFEST_LIST: nginx/nginx:1.27.0-alpine
+  IMAGE_MANIFEST_SINGLE: nginx/nginx:1.27.0-alpine-slim-amd64
   REGCTL_VERSION: v0.8.0
   REGISTRY_LOCAL: localhost:5000
   REGISTRY_REMOTE: public.ecr.aws
@@ -37,11 +38,11 @@ jobs:
       - name: Create registry backup directory
         run: mkdir -p ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
       - name: Pull images data and prepare context directory
-        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           #!/bin/bash
 
+          # run local registry
           docker run -d \
             -p 5000:5000 \
             --name mcvs-registry-tmp \
@@ -80,3 +81,18 @@ jobs:
           dockle-accept-key: "curl,HOME,libcrypto3,libssl3,PATH"
           images: ghcr.io/${{ github.repository }}/${{ matrix.build-args }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get new registry catalog
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          #!/bin/bash
+          docker images
+
+          docker run -d \
+            -p 5005:5000 \
+            --name mcvs-registry \
+            ghcr.io/${{ github.repository }}/${{ env.BUILD_IMAGE_NAME }}:pr-${{ github.event.number }}
+
+          curl --silent http://localhost:5005/v2/_catalog
+
+          docker rm --force mcvs-registry

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -103,6 +103,7 @@ jobs:
           curl http://localhost:5001/v2/_catalog
 
           ls -lah ${{ env.DOCKERFILE_CONTEXT }}
+          ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
 
           docker exec mcvs-registry \
             ash -c 'cat /etc/docker/registry/config.yml'

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -72,7 +72,7 @@ jobs:
           # export images files to backup directory
           docker \
             cp \
-            mcvs-registry-tmp:/var/lib/registry \
+            mcvs-registry-tmp:/var/lib/registry/. \
             ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
 
           # clean up the registry container
@@ -104,7 +104,6 @@ jobs:
 
           ls -lah ${{ env.DOCKERFILE_CONTEXT }}
           ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
-          ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry/registry
 
           docker exec mcvs-registry \
             ash -c 'cat /etc/docker/registry/config.yml'

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -93,12 +93,23 @@ jobs:
           docker images
 
           docker run -d \
-            -p 5005:5000 \
+            -p 5001:5000 \
             --name mcvs-registry \
             ${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
           docker ps
 
-          curl -vk http://localhost:5005/v2/_catalog
+          docker exec -it mcvs-registry \
+            ash -c 'cat /etc/docker/registry/config.yml'
+
+          docker exec -it mcvs-registry \
+            ash -c \
+            'cat /etc/distribution/config.yml'
+
+          docker exec -it mcvs-registry \
+            ash -c \
+            'ls -lah /var/lib/registry/docker/registry/v2/repositories'
+
+          curl http://localhost:5001/v2/_catalog
 
           docker rm --force mcvs-registry

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -102,18 +102,4 @@ jobs:
 
           curl http://localhost:5001/v2/_catalog
 
-          ls -lah ${{ env.DOCKERFILE_CONTEXT }}
-          ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
-
-          docker exec mcvs-registry \
-            ash -c 'cat /etc/docker/registry/config.yml'
-
-          docker exec mcvs-registry \
-            ash -c \
-            'cat /etc/distribution/config.yml'
-
-          docker exec mcvs-registry \
-            ash -c \
-            'ls -lah /var/lib/registry/docker/registry/v2/repositories'
-
           docker rm --force mcvs-registry

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -90,6 +90,7 @@ jobs:
         shell: bash
         run: |
           #!/bin/bash
+
           docker images
 
           docker run -d \
@@ -100,6 +101,8 @@ jobs:
           docker ps
 
           curl http://localhost:5001/v2/_catalog
+
+          ls -lah ${{ env.DOCKERFILE_CONTEXT }}
 
           docker exec mcvs-registry \
             ash -c 'cat /etc/docker/registry/config.yml'

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -6,9 +6,11 @@ name: docker-mcvs-registry
       - "*"
     paths:
       - "registry/**"
+      - ".github/workflows/mcvs-registry.yml"
   pull_request:
     paths:
       - "registry/**"
+      - ".github/workflows/mcvs-registry.yml"
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -97,6 +97,8 @@ jobs:
             --name mcvs-registry \
             ${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
-          curl --silent http://localhost:5005/v2/_catalog
+          docker ps
+
+          curl -vk http://localhost:5005/v2/_catalog
 
           docker rm --force mcvs-registry

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -99,17 +99,17 @@ jobs:
 
           docker ps
 
-          docker exec -it mcvs-registry \
+          curl http://localhost:5001/v2/_catalog
+
+          docker exec mcvs-registry \
             ash -c 'cat /etc/docker/registry/config.yml'
 
-          docker exec -it mcvs-registry \
+          docker exec mcvs-registry \
             ash -c \
             'cat /etc/distribution/config.yml'
 
-          docker exec -it mcvs-registry \
+          docker exec mcvs-registry \
             ash -c \
             'ls -lah /var/lib/registry/docker/registry/v2/repositories'
-
-          curl http://localhost:5001/v2/_catalog
 
           docker rm --force mcvs-registry

--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -104,6 +104,7 @@ jobs:
 
           ls -lah ${{ env.DOCKERFILE_CONTEXT }}
           ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry
+          ls -lah ${{ env.DOCKERFILE_CONTEXT }}/backup-registry/registry
 
           docker exec mcvs-registry \
             ash -c 'cat /etc/docker/registry/config.yml'

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -8,6 +8,6 @@ RUN apk update && \
 # https://github.com/distribution/distribution-library-image
 # File is copied to two different locations to keep
 # compatibility with registry:2.x and registry:3.x
-COPY ./config-example.yml /etc/docker/registry/config.yml
-COPY ./config-example.yml /etc/distribution/config.yml
-COPY ./backup-registry /var/lib/registry
+COPY config-example.yml /etc/docker/registry/config.yml
+COPY config-example.yml /etc/distribution/config.yml
+COPY backup-registry /var/lib/registry


### PR DESCRIPTION
## What
- Updated the test image's name and tag to use NGINX 
- Added new step on the pipeline to check the registry content

## Why
- New images are smaller
- We need to verify the contents of the mcvs-registry image 