### PR TITLE
fix: Omit install of ca-certificates packages as it is updated in the base golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apk update && \
     apk upgrade && \
     apk add \
       --no-cache \
-        ca-certificates=~20241010 \
         git=~2 \
         tzdata=~2024 && \
     update-ca-certificates


### PR DESCRIPTION
When the golang base image is updated, then the ca-certificates package is updated as well. In other words, install of ca-certificates is superfluous.