### PR TITLE
fix: update tzdata package installation in Dockerfile and update Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update && \
     apk add \
       --no-cache \
         git=~2 \
-        tzdata=~2024 && \
+        tzdata=~2025 && \
     update-ca-certificates
 # By copying go.mod and go.sum files in a separate step and running go mod
 # download right after, the Dockerfile ensures that dependency resolution and

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ can be used as a stub server to mimic behavior of other services.
 ```zsh
 docker build -t stub-server --build-arg APPLICATION=mcvs-stub-server .
 ```
+**Note:**
+When building locally, the tzdata package download might fail. To fix this on your local machine, change the version in [Dockerfile:17](Dockerfile)
 
 ### Run
 
@@ -79,6 +81,16 @@ curl --location 'localhost:8080/configure' \
 
 ```
 curl --location 'localhost:8080/foo'
+```
+
+**Reset a configured endpoint**
+
+```
+curl --location 'localhost:8080/reset' \
+--header 'Content-Type: application/json' \
+--data '{
+    "path": "/foo"
+}'
 ```
 
 ## Okta

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ can be used as a stub server to mimic behavior of other services.
 ```zsh
 docker build -t stub-server --build-arg APPLICATION=mcvs-stub-server .
 ```
-**Note:**
-When building locally, the tzdata package download might fail. To fix this on your local machine, change the version in [Dockerfile:17](Dockerfile)
 
 ### Run
 


### PR DESCRIPTION


## What & Why
- I added steps to reset an endpoint, so it's easier to follow
- I changed the tzdata version, because it caused the image build to fail


