### PR TITLE
build: update code coverage expectation in golang workflow

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,6 +1,6 @@
 ---
 name: Golang
-"on":
+'on':
   # required by gomod-go-version-updater to trigger this action once pr has
   # been reviewed
   pull_request_review:
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: schubergphilis/mcvs-golang-action@v0.17.0
         with:
-          code-coverage-expected: 64.6
+          code-coverage-expected: 65.4
           golang-unit-tests-exclusions: |-
             \(cmd\/mcvs-integrationtest-services\|cmd\/oktamock\)
           testing-type: ${{ matrix.testing-type }}


### PR DESCRIPTION
The actual code coverage: '65.4' exceeds the expected coverage. adjust the threshold that is defined in the .github/workflows/golang.yml workflow from '64.6' to '65.4'.