### PR TITLE
feat: [#65] Ensure that docker registry image is built on every git push to prevent that the pipeline will break on tag creation

### DIFF
--- a/.github/workflows/mcvs-registry.yml
+++ b/.github/workflows/mcvs-registry.yml
@@ -2,8 +2,6 @@
 name: docker-mcvs-registry
 "on":
   push:
-    tags:
-      - "*"
     paths:
       - "registry/**"
       - ".github/workflows/mcvs-registry.yml"
@@ -77,7 +75,6 @@ jobs:
 
           # clean up the registry container
           docker rm -f mcvs-registry-tmp
-
       - uses: schubergphilis/mcvs-docker-action@v0.6.1
         with:
           build-args: ${{ matrix.build-args }}
@@ -86,7 +83,7 @@ jobs:
           images: ${{ env.IMAGE_REPO }}/${{ matrix.build-args }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get new registry catalog
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         shell: bash
         run: |
           #!/bin/bash

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:3.0.0-rc.2
+FROM registry:3.0.0-rc.3
 ARG APPLICATION
 RUN apk update && \
     apk upgrade


### PR DESCRIPTION
Currently, the registry image is built only if a tag is created resulting in a failing **tag** build due to the occurrence of a critical issue detected in [the pipeline](https://github.com/schubergphilis/mcvs-integrationtest-services/actions/runs/13702598402/job/38319943656):

![Screenshot 2025-03-07 at 11 45 51](https://github.com/user-attachments/assets/05e7ce1f-5e71-46ec-a910-aa240108687e)

Note: the image push will [only occur on tag](https://github.com/schubergphilis/mcvs-docker-action/blob/main/action.yml#L144C7-L144C76) as the check resides in the mcvs-golang-docker action that is used within this repository.

By updating the tag from 3.0.0-rc.2 to 3.0.0-rc.3 the critical vulnerability will be resolved. Note: as the latter version is not marked as latest, Dependabot was not able to update it.