### PR TITLE
fix: [#65] Enable dependabot for registry image to ensure that it gets updated regularly to prevent security issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       docker-all:
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directory: "/registry"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-registry-image-all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Enable dependabot for registry-image to prevent security issues.