### PR TITLE
fix: problem that model of stub server was in internal package - models.EndpointRequest should be accessible externally to execute requests

### DIFF
--- a/internal/app/stubserver/server.go
+++ b/internal/app/stubserver/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/schubergphilis/mcvs-integrationtest-services/pkg/stubserver/models"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -46,21 +47,21 @@ func (s *Server) health(c *gin.Context) {
 }
 
 func (s *Server) addResponse(c *gin.Context) {
-	var request EndpointRequest
+	var request models.EndpointRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request body"})
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid request body"})
 
 		return
 	}
 
 	if request.Path == "" || request.HTTPMethod == "" {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Path and HTTP method are required"})
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Path and HTTP method are required"})
 
 		return
 	}
 
 	if request.ResponseBody == "" {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Response body is required"})
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Response body is required"})
 
 		return
 	}
@@ -79,7 +80,7 @@ func (s *Server) addResponse(c *gin.Context) {
 
 	err := s.responseManager.AddEndpoint(endpointConfig)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: err.Error()})
 
 		return
 	}
@@ -90,9 +91,9 @@ func (s *Server) addResponse(c *gin.Context) {
 func (s *Server) getAllResponses(c *gin.Context) {
 	configs := s.responseManager.GetAllEndpointConfigurations()
 
-	responses := make([]EndpointResponse, 0, len(configs))
+	responses := make([]models.EndpointResponse, 0, len(configs))
 	for _, config := range configs {
-		responses = append(responses, EndpointResponse{
+		responses = append(responses, models.EndpointResponse{
 			Path:               config.EndpointID.Path,
 			HTTPMethod:         config.EndpointID.HTTPMethod,
 			QueryParamsToMatch: config.EndpointID.QueryParamsToMatch,
@@ -103,7 +104,7 @@ func (s *Server) getAllResponses(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, EndpointListResponse{Endpoints: responses})
+	c.JSON(http.StatusOK, models.EndpointListResponse{Endpoints: responses})
 }
 
 func (s *Server) deleteAllResponses(c *gin.Context) {

--- a/pkg/stubserver/client/client.go
+++ b/pkg/stubserver/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"github.com/schubergphilis/mcvs-integrationtest-services/internal/app/stubserver"
+	"github.com/schubergphilis/mcvs-integrationtest-services/pkg/stubserver/models"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -77,7 +78,7 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 }
 
 // AddResponse adds a new response to the stub server.
-func (c *Client) AddResponse(ctx context.Context, request stubserver.EndpointRequest) error {
+func (c *Client) AddResponse(ctx context.Context, request models.EndpointRequest) error {
 	data, err := json.Marshal(request)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
@@ -93,7 +94,7 @@ func (c *Client) AddResponse(ctx context.Context, request stubserver.EndpointReq
 	defer closeResponseBody(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		var errorResp stubserver.ErrorResponse
+		var errorResp models.ErrorResponse
 		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
 			return fmt.Errorf("failed with status code %d", resp.StatusCode)
 		}
@@ -105,7 +106,7 @@ func (c *Client) AddResponse(ctx context.Context, request stubserver.EndpointReq
 }
 
 // GetAllResponses retrieves all responses from the stub server.
-func (c *Client) GetAllResponses(ctx context.Context) ([]stubserver.EndpointResponse, error) {
+func (c *Client) GetAllResponses(ctx context.Context) ([]models.EndpointResponse, error) {
 	url := fmt.Sprintf("%s%s%s", c.baseURL, stubserver.BaseURLPath, stubserver.ResponsesEndpoint)
 
 	resp, err := c.doRequest(ctx, http.MethodGet, url, nil, nil)
@@ -118,7 +119,7 @@ func (c *Client) GetAllResponses(ctx context.Context) ([]stubserver.EndpointResp
 		return nil, fmt.Errorf("failed with status code %d", resp.StatusCode)
 	}
 
-	var listResponse stubserver.EndpointListResponse
+	var listResponse models.EndpointListResponse
 	if err := json.NewDecoder(resp.Body).Decode(&listResponse); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}

--- a/pkg/stubserver/client/client_test.go
+++ b/pkg/stubserver/client/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/schubergphilis/mcvs-integrationtest-services/internal/app/stubserver"
+	"github.com/schubergphilis/mcvs-integrationtest-services/pkg/stubserver/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -43,7 +44,7 @@ func (s *StubServerTestSuite) TestHealthCheck() {
 }
 
 func (s *StubServerTestSuite) TestAddResponse() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/test",
 		HTTPMethod:         http.MethodGet,
 		ResponseBody:       "test response",
@@ -65,12 +66,12 @@ func (s *StubServerTestSuite) TestAddResponse() {
 func (s *StubServerTestSuite) TestAddResponseWithInvalidData() {
 	testCases := []struct {
 		name          string
-		request       stubserver.EndpointRequest
+		request       models.EndpointRequest
 		errorContains string
 	}{
 		{
 			name: "missing path",
-			request: stubserver.EndpointRequest{
+			request: models.EndpointRequest{
 				HTTPMethod:         http.MethodGet,
 				ResponseBody:       "test response",
 				ResponseStatusCode: http.StatusOK,
@@ -79,7 +80,7 @@ func (s *StubServerTestSuite) TestAddResponseWithInvalidData() {
 		},
 		{
 			name: "missing HTTP method",
-			request: stubserver.EndpointRequest{
+			request: models.EndpointRequest{
 				Path:               "/test",
 				ResponseBody:       "test response",
 				ResponseStatusCode: http.StatusOK,
@@ -88,7 +89,7 @@ func (s *StubServerTestSuite) TestAddResponseWithInvalidData() {
 		},
 		{
 			name: "missing response body",
-			request: stubserver.EndpointRequest{
+			request: models.EndpointRequest{
 				Path:               "/test",
 				HTTPMethod:         http.MethodGet,
 				ResponseStatusCode: http.StatusOK,
@@ -107,7 +108,7 @@ func (s *StubServerTestSuite) TestAddResponseWithInvalidData() {
 }
 
 func (s *StubServerTestSuite) TestAddDuplicateEndpoint() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/test",
 		HTTPMethod:         http.MethodGet,
 		ResponseBody:       "test response",
@@ -123,7 +124,7 @@ func (s *StubServerTestSuite) TestAddDuplicateEndpoint() {
 }
 
 func (s *StubServerTestSuite) TestGetAllResponses() {
-	responses := []stubserver.EndpointRequest{
+	responses := []models.EndpointRequest{
 		{
 			Path:               "/test1",
 			HTTPMethod:         http.MethodGet,
@@ -153,7 +154,7 @@ func (s *StubServerTestSuite) TestGetAllResponses() {
 }
 
 func (s *StubServerTestSuite) TestDeleteAllResponses() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/test",
 		HTTPMethod:         http.MethodGet,
 		ResponseBody:       "test response",
@@ -176,7 +177,7 @@ func (s *StubServerTestSuite) TestDeleteAllResponses() {
 }
 
 func (s *StubServerTestSuite) TestSendRequestWithQueryParamsMatching() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/api/v1/products",
 		HTTPMethod:         http.MethodGet,
 		QueryParamsToMatch: map[string]string{"page": "3", "limit": "25"},
@@ -219,7 +220,7 @@ func (s *StubServerTestSuite) TestSendRequestWithQueryParamsMatching() {
 }
 
 func (s *StubServerTestSuite) TestSendRequestWithHeadersMatching() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/api/v1/users",
 		HTTPMethod:         http.MethodGet,
 		HeadersToMatch:     map[string]string{"X-Page": "2", "X-Per-Page": "50"},
@@ -261,7 +262,7 @@ func (s *StubServerTestSuite) TestSendRequestWithHeadersMatching() {
 }
 
 func (s *StubServerTestSuite) TestSendRequestWithBothHeadersAndQueryParams() {
-	testRequest := stubserver.EndpointRequest{
+	testRequest := models.EndpointRequest{
 		Path:               "/api/v1/orders",
 		HTTPMethod:         http.MethodGet,
 		QueryParamsToMatch: map[string]string{"sort": "created_at", "order": "desc"},
@@ -304,7 +305,7 @@ func (s *StubServerTestSuite) TestSendRequestWithBothHeadersAndQueryParams() {
 }
 
 func (s *StubServerTestSuite) TestSendRequestWithBody() {
-	createUserRequest := stubserver.EndpointRequest{
+	createUserRequest := models.EndpointRequest{
 		Path:               "/api/users",
 		HTTPMethod:         http.MethodPost,
 		ResponseHeaders:    map[string]string{"Content-Type": "application/json"},

--- a/pkg/stubserver/models/models.go
+++ b/pkg/stubserver/models/models.go
@@ -1,4 +1,4 @@
-package stubserver
+package models
 
 // EndpointRequest represents the request body for adding a new endpoint.
 type EndpointRequest struct {


### PR DESCRIPTION
Fix problem that model of stub server was in internal package.
Move model of client for stub server to public package model,